### PR TITLE
Add Key.ID field to convert to support copy ID in task list in eclipse?

### DIFF
--- a/com.itsolut.mantis.core/src/com/itsolut/mantis/core/soap/MantisConverter.java
+++ b/com.itsolut.mantis.core/src/com/itsolut/mantis/core/soap/MantisConverter.java
@@ -62,6 +62,8 @@ public class MantisConverter {
 
         ticket.putBuiltinValue(Key.PROJECT, issue.getProject().getName());
 
+	ticket.putBuiltinValue(Key.ID, issue.getId().intValue());
+
         ticket.putBuiltinValue(Key.SUMMARY, issue.getSummary());
         ticket.putBuiltinValue(Key.DESCRIPTION, issue.getDescription());
         ticket.putBuiltinValue(Key.CATEOGRY, issue.getCategory());


### PR DESCRIPTION
In mylyn mantisbt when ID is copied there is nothing. Perhaps this change will fix it. Unfortunately I have not been able to test it. This pull request allows me to report the issue as I cannot sign up in the mantisbt bug tracker at the moment.

main issues I find in eclipse are:
1) task Id is not listed when I open the task
2) task Id is not copied when I copy id in right click menu in task list
3) there is not ctrl-click in comments when the bug is mentioned by id (the full url must be added) I'd rather have a comment like:
// see bug-4511